### PR TITLE
Homepage standard Casper: rimozione sezioni brand e feed List

### DIFF
--- a/index.hbs
+++ b/index.hbs
@@ -43,22 +43,9 @@ into the {body} of the default.hbs template --}}
 
 </div>
 
-{{!-- Personal intro banner — first page only --}}
-{{#unless pagination.prev}}
-    {{> "brand/home-topic-hubs"}}
-    {{> "brand/home-photo-gallery"}}
-{{/unless}}
-
 {{!-- The main content area --}}
 <main id="site-main" class="site-main outer">
 <div class="inner posts">
-    {{#unless pagination.prev}}
-        <header class="aa-home-section-heading is-feed-heading">
-            <span class="aa-page-eyebrow">Cronologia</span>
-            <h2 class="aa-home-section-title">Articoli recenti</h2>
-            <p class="aa-home-section-copy">Ultimi contenuti pubblicati.</p>
-        </header>
-    {{/unless}}
 
     <div class="post-feed">
         {{#foreach posts}}

--- a/package.json
+++ b/package.json
@@ -29,13 +29,13 @@
     "author": {
         "name": "Adriano Amalfi",
         "email": "info@adrianoamalfi.com",
-        "url": "https://adrianoamalfi.com"        
+        "url": "https://adrianoamalfi.com"
     },
     "gpm": {
         "type": "theme",
         "categories": [
             "Minimal",
-            "Magazine", 
+            "Magazine",
             "Customizable",
             "Personal",
             "Responsive",
@@ -192,7 +192,7 @@
                     "Grid",
                     "List"
                 ],
-                "default": "Classic",
+                "default": "List",
                 "group": "homepage"
             },
             "color_scheme": {


### PR DESCRIPTION
## Cosa cambia

- **index.hbs**: rimosse le sezioni brand della homepage (topic hubs, photo gallery) e l'intestazione del feed — la homepage torna al layout standard Casper (header sito → feed → paginazione)
- **package.json**: `feed_layout` default → `List` (lista cronologica uniforme invece del layout Classic con card grande + griglia dinamica)

I partial `brand/home-*` restano nel tema: sono usati da `index-photos.hbs` e `index-ai-art.hbs`. Invariate le ottimizzazioni immagini (`media/picture-*`).

## Nota post-deploy

Se su Ghost Admin il **Feed layout** era stato impostato esplicitamente, il valore salvato prevale sul default del tema: dopo il deploy verificare in **Admin → Design → Homepage → Feed layout** che sia su `List`.

gscan: ✓ compatibile Ghost 6.x

🤖 Generated with [Claude Code](https://claude.com/claude-code)